### PR TITLE
Support naming profiles after account alias or number

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,8 +102,9 @@ A configuration wizard will prompt you to enter the necessary configuration para
 - cred_profile - If writing to the AWS cred file, this sets the name of the AWS credential profile.
   - The reserved word `role` will use the name component of the role arn as the profile name. i.e. arn:aws:iam::123456789012:role/okta-1234-role becomes section [okta-1234-role] in the aws credentials file
   - The reserved word `acc-role` will use the name component of the role arn prepended with account number (or alias if `resolve_aws_alias` is set to y) to avoid collisions, i.e. arn:aws:iam::123456789012:role/okta-1234-role becomes section [123456789012-okta-1234-role], or if `resolve_aws_alias` [<my alias>-okta-1234-role] in the aws credentials file
+  - The reserved word `acc` will use the account number (or alias if `resolve_aws_alias` is set to y).
   - If set to `default` then the temp creds will be stored in the default profile
-  - Note: if there are multiple roles, and `default` is selected it will be overwritten multiple times and last role wins. The same happens when `role` is selected and you have many accounts with the same role names. Consider using `acc-role` if this happens.
+  - Note: if there are multiple roles, and `default` is selected it will be overwritten multiple times and last role wins. The same happens when `role` or `acc` is selected and you have many accounts with the same role names. Consider using `acc-role` if this happens.
 - aws_appname - This is optional. The Okta AWS App name, which has the role you want to assume.
 - aws_rolename - This is optional. The ARN of the role you want temporary AWS credentials for.  The reserved word 'all' can be used to get and store credentials for every role the user is permissioned for.
 - aws_default_duration = This is optional. Lifetime for temporary credentials, in seconds. Defaults to 1 hour (3600)

--- a/gimme_aws_creds/config.py
+++ b/gimme_aws_creds/config.py
@@ -431,6 +431,7 @@ class Config(object):
         ui.default.message(
             "The AWS credential profile defines which profile is used to store the temp AWS creds.\n"
             "If set to 'role' then a new profile will be created matching the role name assumed by the user.\n"
+            "If set to 'acc' then a new profile will be created matching the account number (or alias if resolve is set to True)\n"
             "If set to 'acc-role' then a new profile will be created matching the role name assumed by the user, but prefixed with account number to avoid collisions.\n"
             "If set to 'default' then the temp creds will be stored in the default profile\n"
             "If set to any other value, the name of the profile will match that value."
@@ -439,7 +440,7 @@ class Config(object):
         cred_profile = self._get_user_input(
             "AWS Credential Profile", default_entry)
 
-        if cred_profile.lower() in ['default', 'role', 'acc-role']:
+        if cred_profile.lower() in ['default', 'role', 'acc', 'acc-role']:
             cred_profile = cred_profile.lower()
 
         return cred_profile

--- a/gimme_aws_creds/main.py
+++ b/gimme_aws_creds/main.py
@@ -752,6 +752,13 @@ class GimmeAWSCreds(object):
             profile_name = 'default'
         elif cred_profile.lower() == 'role':
             profile_name = naming_data['role']
+        elif cred_profile.lower() == 'acc':
+            account = naming_data['account']
+            if resolve_alias == 'True':
+                account_alias = self._get_alias_from_friendly_name(role.friendly_account_name)
+                if account_alias:
+                    account = account_alias
+            profile_name = account
         elif cred_profile.lower() == 'acc-role':
             account = naming_data['account']
             role_name = naming_data['role']

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -218,6 +218,33 @@ class TestMain(unittest.TestCase):
         self.assertEqual(creds.get_profile_name(cred_profile, include_path, naming_data, resolve_alias, role),
                          'administrator')
 
+    # From https://github.com/Nike-Inc/gimme-aws-creds/pull/294/files
+    def test_get_profile_name_acc_resolve_alias(self):
+        "Testing the acc, with alias resolution, and not including full role path"
+        creds = GimmeAWSCreds()
+        naming_data = {'account': '123456789012', 'role': 'administrator', 'path': '/administrator/'}
+        role = RoleSet(idp='arn:aws:iam::123456789012:saml-provider/my-okta-provider',
+                       role='arn:aws:iam::123456789012:role/administrator/administrator',
+                       friendly_account_name='Account: my-org-master (123456789012)',
+                       friendly_role_name='administrator/administrator')
+        cred_profile = 'acc'
+        resolve_alias = 'False'
+        include_path = 'False'
+        self.assertEqual(creds.get_profile_name(cred_profile, include_path, naming_data, resolve_alias, role), "123456789012")
+
+    def test_get_profile_name_acc_do_not_resolve_alias(self):
+        "Testing the acc, with alias resolution, and not including full role path"
+        creds = GimmeAWSCreds()
+        naming_data = {'account': '123456789012', 'role': 'administrator', 'path': '/administrator/'}
+        role = RoleSet(idp='arn:aws:iam::123456789012:saml-provider/my-okta-provider',
+                       role='arn:aws:iam::123456789012:role/administrator/administrator',
+                       friendly_account_name='Account: my-org-master (123456789012)',
+                       friendly_role_name='administrator/administrator')
+        cred_profile = 'acc'
+        resolve_alias = 'True'
+        include_path = 'False'
+        self.assertEqual(creds.get_profile_name(cred_profile, include_path, naming_data, resolve_alias, role), "my-org-master")
+    
     def test_get_profile_name_default(self):
         "Testing the default"
         creds = GimmeAWSCreds()


### PR DESCRIPTION
Functionally a copy of https://github.com/Nike-Inc/gimme-aws-creds/pull/294

## Description
In many orgs (like mine) we use a single role in multiple accounts, and we name our aws profiles after the account name.

## Related Issue
Resolves #293

## Motivation and Context
We have a lot of AWS accounts, and their names are long enough - using the roles makes it hard to use the cli with the resulting credentials.

## How Has This Been Tested?
Added UT

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
